### PR TITLE
Fixed an import name in the file that it was referencing 'imagestore'…

### DIFF
--- a/components/ImageGrid.js
+++ b/components/ImageGrid.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Reflux from 'reflux';
-import ImageStore from '../stores/imagestore';
+import ImageStore from '../stores/ImageStore';
 
 var ImageGrid = React.createClass({
   mixins: [Reflux.connect(ImageStore, 'imagestore')],


### PR DESCRIPTION
In the file ImageGrid.js the import line was:

``` javascript
import ImageStore from '../stores/imagestore';
```

So I changed it to:

``` javascript
import ImageStore from '../stores/ImageStore';
```

Now `npm run build` works at expected
